### PR TITLE
Zone delete improvements

### DIFF
--- a/library/memset_zone.py
+++ b/library/memset_zone.py
@@ -42,7 +42,7 @@ options:
     force:
         required: false
         description:
-            - Forces deletion of a zone and all zone domains/zone records it containsn.
+            - Forces deletion of a zone and all zone domains/zone records it contains.
 '''
 
 EXAMPLES = '''

--- a/playbooks/delete/all_in_one_delete.yaml
+++ b/playbooks/delete/all_in_one_delete.yaml
@@ -5,7 +5,7 @@
  
   tasks:
   - name: include secrets
-    include_vars: secrets.yaml
+    include_vars: ../secrets.yaml
 
   - name: delete zone
     local_action:


### PR DESCRIPTION
exit without change if a zone containing a domain has already been deleted (as the user wishes the domain to be removed, which has already happened).